### PR TITLE
Move page number to bottom right

### DIFF
--- a/VUMIFInfKursinis.cls
+++ b/VUMIFInfKursinis.cls
@@ -46,10 +46,10 @@
 \renewcommand{\footrulewidth}{0pt}
 \lhead{}
 \chead{}
-\rhead{\thepage}  % Numeris bus puslapio viršuje dešinėje
+\rhead{}
 \lfoot{}
 \cfoot{}
-\rfoot{}
+\rfoot{\thepage}  % Numeris bus puslapio apačioje dešinėje
 
 % Nerodyti įspėjimo dėl pakeistos article klasės antraščių stiliaus
 \RequirePackage{silence}


### PR DESCRIPTION
As per http://www.mif.vu.lt/katedros/se/Studentams/KURSINIO%20DARBO%20METODINIAI%20NURODYMAI%202011_AL.pdf the page number needs to be in the bottom right.

Ref: #1 
